### PR TITLE
test: extend timeout for 20-main-project.md

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
 
       # Upload the book's HTML as an artifact
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "deep-learning-intro-for-hep/_build/html"
 
@@ -69,4 +69,4 @@ jobs:
         id: deployment
         # only deploy if merging into main, not if testing a PR
         if: github.ref_name == 'main'
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
       # Preload the main project data
       - name: Preload main project data
         run: |
-          python -c 'import sklearn; hls4ml_lhc_jets_hlf = sklearn.datasets.fetch_openml("hls4ml_lhc_jets_hlf"); features, targets = hls4ml_lhc_jets_hlf["data"], hls4ml_lhc_jets_hlf["target"]'
+          python -c 'import sklearn.datasets; d = sklearn.datasets.fetch_openml("hls4ml_lhc_jets_hlf"); d["data"], d["target"]'
 
       # Build the book
       - name: Build the book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,11 @@ jobs:
           cache-environment: true
           post-cleanup: "all"
 
+      # Preload the main project data
+      - name: Preload main project data
+        run: |
+          python -c 'import sklearn; hls4ml_lhc_jets_hlf = sklearn.datasets.fetch_openml("hls4ml_lhc_jets_hlf"); features, targets = hls4ml_lhc_jets_hlf["data"], hls4ml_lhc_jets_hlf["target"]'
+
       # Build the book
       - name: Build the book
         run: |

--- a/deep-learning-intro-for-hep/20-main-project.md
+++ b/deep-learning-intro-for-hep/20-main-project.md
@@ -12,7 +12,7 @@ kernelspec:
   language: python
   name: python3
 execution:
-  timeout: 600
+  timeout: 120
 ---
 
 # Main Project (2 hours)

--- a/deep-learning-intro-for-hep/20-main-project.md
+++ b/deep-learning-intro-for-hep/20-main-project.md
@@ -12,7 +12,7 @@ kernelspec:
   language: python
   name: python3
 execution:
-  timeout: 120
+  timeout: 600
 ---
 
 # Main Project (2 hours)


### PR DESCRIPTION
The scheduled tests failed for the past 12 days in a row, but for a variety of reasons:

```
2025-01-08	03-basic-fitting.md     assert np.sum((y_from_ansatz - y)**2) < 100
2025-01-09	24-convolutional.md     assert confusion_matrix[0:2, 2:].sum() / confusion_matrix[0:2].sum() < 0.5
2025-01-10      24-convolutional.md     assert confusion_matrix[0:2, 2:].sum() / confusion_matrix[0:2].sum() < 0.5
2025-01-11      20-main-project.md      A cell timed out while it was being executed, after 120 seconds.
2025-01-12      20-main-project.md      A cell timed out while it was being executed, after 120 seconds.
2025-01-13      20-main-project.md      A cell timed out while it was being executed, after 120 seconds.
2025-01-14      20-main-project.md      A cell timed out while it was being executed, after 120 seconds.
2025-01-15      20-main-project.md      A cell timed out while it was being executed, after 120 seconds.
2025-01-16      03-basic-fitting.md     assert np.sum((y_from_ansatz - y)**2) < 100
2025-01-17      20-main-project.md      A cell timed out while it was being executed, after 120 seconds.
2025-01-18      20-main-project.md      A cell timed out while it was being executed, after 120 seconds.
2025-01-19      04-universal-approximators.md  assert np.sum((model_y - curve_y)**2) < 10
```

The most common of these is that the cell execution timeout on 20-main-project.md is too short. It's reasonable to make that longer, so this PR extends it to 10 minutes (overkill). The assertions, however, are important for ensuring that the web pages show correct results from a fitter whose initial state is non-deterministic—Minuit in all of the above cases. The only way the assertions could be improved would be by setting a PRNG seed in iminuit or set the initial fit parameters closer to the minimum (which undermines the lesson). I don't see a way to set the seed in iminuit, but if anyone has any ideas, that would be great.

Meanwhile, I'm only addressing the timeouts in this PR. We should see the tests pass more often, but not every day.